### PR TITLE
Fix unescaped quotes in doc_page.lsp S-expression string

### DIFF
--- a/gen/doc_page.lsp
+++ b/gen/doc_page.lsp
@@ -32,7 +32,7 @@
   In the default setting, a \\ref BRST_Doc object has one `Pages` object as root of pages.
   All `Page` objects are created as a child of `Pages` object. Since `Pages` object can
   own only 8191 child objects, the maximum number of pages are 8191 pages. Additionally,
-  the case when there are a lot of "Page" object under one "Pages" object is not good,
+  the case when there are a lot of \"Page\" object under one \"Pages\" object is not good,
   since it causes performance degradation of a viewer application.
 
   An application can change the setting of a pages tree by invoking BRST_SetPagesConfiguration().


### PR DESCRIPTION
While prototyping a Ruby FFI generator (bindings/ruby-ffi/generator.rb, related to #19) I hit a parse error on gen/doc_page.lsp. Line 35 contains unescaped "Page" and "Pages" inside a multi-line :en string literal.

ECL's reader is lenient enough that the existing pipeline in bindings/ecl/ecl.sh still works, so this has gone unnoticed. However, generic S-expression parsers in other languages (Ruby's sxp, Python's sexpdata, etc.) treat those quotes as string terminators and mis-tokenize the form, which breaks any attempt to consume these files as a source of truth from non-ECL bindings.

This PR escapes the two quotes so the file is robustly parseable everywhere, without changing the rendered docstring. I also ran a quick scan over the rest of gen/*.lsp and this was the only occurrence.

Related: #19, #10
