### PR TITLE
Security fixes demos

### DIFF
--- a/data/spell/hunspell.dict
+++ b/data/spell/hunspell.dict
@@ -431,6 +431,7 @@ SimHei
 SimSun
 Soleil
 StampAnnotName
+StrCopy
 StrokeColorSpace
 struct
 structs

--- a/demo/arc_demo.c
+++ b/demo/arc_demo.c
@@ -39,11 +39,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
-    BRST_Point pos;
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);
@@ -81,7 +83,7 @@ int main(int argc, char** argv)
     BRST_Page_MoveTo(page, cx, cy);
     BRST_Page_LineTo(page, cx, cx + r);
     BRST_Page_Arc(page, cx, cy, r, 0, 360 * 0.45);
-    pos = BRST_Page_CurrentPos(page);
+    BRST_Point pos = BRST_Page_CurrentPos(page);
     BRST_Page_LineTo(page, cx, cy);
     BRST_Page_Fill(page);
 

--- a/demo/attach.c
+++ b/demo/attach.c
@@ -21,10 +21,13 @@ main (int argc, char **argv)
 {
     BRST_Doc  pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     pdf = BRST_Doc_New(demo_error_handler, NULL);
     if (!pdf) {

--- a/demo/circle.c
+++ b/demo/circle.c
@@ -43,14 +43,19 @@ void circle(BRST_Page page, BRST_REAL x, BRST_REAL y, BRST_REAL radius) {
     BRST_Page_ClosePath(page);
 } 
 
+#define FNAME_BUFFER_SIZE 256
+
 int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New_Empty();

--- a/demo/clip.c
+++ b/demo/clip.c
@@ -23,14 +23,19 @@
 #include <stdio.h>
 #include <string.h>
 
+#define FNAME_BUFFER_SIZE 256
+
 int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New_Empty();

--- a/demo/dates.c
+++ b/demo/dates.c
@@ -35,10 +35,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/eofill.c
+++ b/demo/eofill.c
@@ -28,10 +28,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/grid_demo.c
+++ b/demo/grid_demo.c
@@ -11,10 +11,13 @@ main (int argc, char **argv)
 {
     BRST_Doc  pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/handler.h
+++ b/demo/handler.h
@@ -4,6 +4,8 @@
 #include "brst.h"
 #include <setjmp.h>
 
+#define FNAME_BUFFER_SIZE 256
+
 BRST_HANDLER(void)
 demo_error_handler(BRST_STATUS error_no,
     BRST_STATUS detail_no,

--- a/demo/line_demo.c
+++ b/demo/line_demo.c
@@ -56,7 +56,13 @@ int main(int argc, char** argv)
     BRST_Doc pdf;
     BRST_Font font;
     BRST_Page page;
-    char fname[256];
+
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     const BRST_REAL DASH_MODE1[] = { 3 };
     const BRST_REAL DASH_MODE2[] = { 3, 7 };
@@ -72,9 +78,6 @@ int main(int argc, char** argv)
     double y3;
 
     float tw;
-
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/minimal.c
+++ b/demo/minimal.c
@@ -39,10 +39,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/minimal_empty.c
+++ b/demo/minimal_empty.c
@@ -33,14 +33,19 @@
 #include <stdio.h>
 #include <string.h>
 
+#define FNAME_BUFFER_SIZE 256
+
 int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New_Empty();

--- a/demo/minimal_text.c
+++ b/demo/minimal_text.c
@@ -28,14 +28,19 @@
 #include <stdio.h>
 #include <string.h>
 
+#define FNAME_BUFFER_SIZE 256
+
 int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New_Empty();

--- a/demo/pattern.c
+++ b/demo/pattern.c
@@ -39,10 +39,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/pattern2.c
+++ b/demo/pattern2.c
@@ -48,10 +48,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/properties.c
+++ b/demo/properties.c
@@ -51,10 +51,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/raw_image_demo.c
+++ b/demo/raw_image_demo.c
@@ -29,13 +29,16 @@ int main(int argc, char **argv)
     BRST_Doc  pdf;
     BRST_Font font;
     BRST_Page page;
-    char fname[256];
+
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
+    
     BRST_Image image;
-
     BRST_REAL x, y;
-
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/scissors.c
+++ b/demo/scissors.c
@@ -27,10 +27,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/utf8.c
+++ b/demo/utf8.c
@@ -38,10 +38,13 @@ main (int argc, char **argv)
     BRST_Doc pdf;
     BRST_Page page;
     BRST_ExtGState gstate;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/xobject.c
+++ b/demo/xobject.c
@@ -34,10 +34,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/xobject_circle.c
+++ b/demo/xobject_circle.c
@@ -21,14 +21,19 @@
 #include <stdio.h>
 #include <string.h>
 
+#define FNAME_BUFFER_SIZE 256
+
 int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New_Empty();

--- a/demo/xobject_pattern.c
+++ b/demo/xobject_pattern.c
@@ -35,10 +35,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/xobject_text.c
+++ b/demo/xobject_text.c
@@ -29,10 +29,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/demo/xobject_xobject.c
+++ b/demo/xobject_xobject.c
@@ -38,10 +38,13 @@ int main(int argc, char** argv)
 {
     BRST_Doc pdf;
     BRST_Page page;
-    char fname[256];
 
-    strcpy(fname, argv[0]);
-    strcat(fname, ".pdf");
+    char fname[FNAME_BUFFER_SIZE];
+    char* pbuf = fname;
+    char* eptr = fname + FNAME_BUFFER_SIZE - 1;
+
+    pbuf = BRST_StrCopy(pbuf, argv[0], eptr);
+    BRST_StrCopy(pbuf, ".pdf",  eptr);
 
     // Создание объекта документа
     pdf = BRST_Doc_New(demo_error_handler, NULL);

--- a/include/brst.h
+++ b/include/brst.h
@@ -42,5 +42,8 @@
 #include "brst_doc_pattern.h"
 #include "brst_doc_page_pattern.h"
 #include "brst_stream_text.h"
+// TODO Вынести эти функции на публичный уровень
+// TODO Или вынести только StrCopy()
+#include "private/brst_utils.h"
 
 #endif /* BRST_H */

--- a/include/brst_types.h
+++ b/include/brst_types.h
@@ -10,6 +10,7 @@
 typedef void*              BRST_RAW_POINTER;
 
 typedef const char*        BRST_CSTR;
+typedef char*              BRST_STR;
 
 /*  native OS integer types */
 typedef signed int         BRST_INT;

--- a/include/private/brst_utils.h
+++ b/include/private/brst_utils.h
@@ -23,21 +23,21 @@ BRST_AToF(
 );
 
 
-char*
+BRST_STR
 BRST_IToA(
     char*      s,
     BRST_INT32 val,
     char*      eptr
 );
 
-char*
+BRST_STR
 BRST_IToA2(
     char*       s,
     BRST_UINT32 val,
     BRST_UINT   len
 );
 
-char*
+BRST_STR
 BRST_FToA(
     char*     s,
     BRST_REAL val,
@@ -51,7 +51,7 @@ BRST_MemCopy(
     BRST_UINT        n
 );
 
-BRST_BYTE*
+BRST_STR
 BRST_StrCopy(
     char*       out,
     const char* in,
@@ -71,7 +71,7 @@ BRST_StrCmp(
     const char* s2
 );
 
-const char*
+BRST_CSTR
 BRST_StrStr(
     const char* s1,
     const char* s2,

--- a/src/brst_base.c
+++ b/src/brst_base.c
@@ -202,7 +202,7 @@ BRST_Doc_Initialize(BRST_Doc pdf)
 
     pdf->cur_pages = pdf->root_pages;
 
-    ptr     = (char*)BRST_StrCopy(ptr, (const char*)"Beresta Free PDF Library ", eptr);
+    ptr     = BRST_StrCopy(ptr, (const char*)"Beresta Free PDF Library ", eptr);
     version = BRST_Version();
     BRST_StrCopy(ptr, version, eptr);
 

--- a/src/brst_geometry.c
+++ b/src/brst_geometry.c
@@ -76,7 +76,7 @@ QuarterEllipseA(char* pbuf,
     pbuf    = BRST_FToA(pbuf, x, eptr);
     *pbuf++ = ' ';
     pbuf    = BRST_FToA(pbuf, y + yray, eptr);
-    return (char*)BRST_StrCopy(pbuf, " c\012", eptr);
+    return BRST_StrCopy(pbuf, " c\012", eptr);
 }
 
 static char*
@@ -98,7 +98,7 @@ QuarterEllipseB(char* pbuf,
     pbuf    = BRST_FToA(pbuf, x + xray, eptr);
     *pbuf++ = ' ';
     pbuf    = BRST_FToA(pbuf, y, eptr);
-    return (char*)BRST_StrCopy(pbuf, " c\012", eptr);
+    return BRST_StrCopy(pbuf, " c\012", eptr);
 }
 
 static char*
@@ -120,7 +120,7 @@ QuarterEllipseC(char* pbuf,
     pbuf    = BRST_FToA(pbuf, x, eptr);
     *pbuf++ = ' ';
     pbuf    = BRST_FToA(pbuf, y - yray, eptr);
-    return (char*)BRST_StrCopy(pbuf, " c\012", eptr);
+    return BRST_StrCopy(pbuf, " c\012", eptr);
 }
 
 static char*
@@ -142,7 +142,7 @@ QuarterEllipseD(char* pbuf,
     pbuf    = BRST_FToA(pbuf, x - xray, eptr);
     *pbuf++ = ' ';
     pbuf    = BRST_FToA(pbuf, y, eptr);
-    return (char*)BRST_StrCopy(pbuf, " c\012", eptr);
+    return BRST_StrCopy(pbuf, " c\012", eptr);
 }
 
 static BRST_STATUS
@@ -198,9 +198,9 @@ InternalArc(BRST_Page page,
         pbuf    = BRST_FToA(pbuf, (BRST_REAL)y0, eptr);
 
         if (attr->gmode == BRST_GMODE_PATH_OBJECT)
-            pbuf = (char*)BRST_StrCopy(pbuf, " l\012", eptr);
+            pbuf = BRST_StrCopy(pbuf, " l\012", eptr);
         else
-            pbuf = (char*)BRST_StrCopy(pbuf, " m\012", eptr);
+            pbuf = BRST_StrCopy(pbuf, " m\012", eptr);
     }
 
     pbuf    = BRST_FToA(pbuf, (BRST_REAL)x1, eptr);
@@ -389,7 +389,7 @@ BRST_Page_Ellipse(BRST_Page page,
     pbuf    = BRST_FToA(pbuf, x - xray, eptr);
     *pbuf++ = ' ';
     pbuf    = BRST_FToA(pbuf, y, eptr);
-    pbuf    = (char*)BRST_StrCopy(pbuf, " m\012", eptr);
+    pbuf    = BRST_StrCopy(pbuf, " m\012", eptr);
 
     pbuf = QuarterEllipseA(pbuf, eptr, x, y, xray, yray);
     pbuf = QuarterEllipseB(pbuf, eptr, x, y, xray, yray);

--- a/src/private/brst_encoder_basic.c
+++ b/src/private/brst_encoder_basic.c
@@ -183,7 +183,7 @@ BRST_BasicEncoder_Write(BRST_Encoder encoder,
                 ptmp    = BRST_IToA(ptmp, i, tmp + BRST_TEXT_DEFAULT_LEN - 1);
                 *ptmp++ = ' ';
                 *ptmp++ = '/';
-                ptmp    = (char*)BRST_StrCopy(ptmp, char_name, tmp + BRST_TEXT_DEFAULT_LEN - 1);
+                ptmp    = BRST_StrCopy(ptmp, char_name, tmp + BRST_TEXT_DEFAULT_LEN - 1);
                 *ptmp++ = ' ';
                 *ptmp   = 0;
 

--- a/src/private/brst_font_cid.c
+++ b/src/private/brst_font_cid.c
@@ -895,17 +895,17 @@ CreateCMap(BRST_Encoder encoder,
     ret += BRST_Stream_WriteStr(cmap->stream,
         "%%IncludeResource: ProcSet (CIDInit)\r\n");
 
-    pbuf = (char*)BRST_StrCopy(buf, "%%BeginResource: CMap (", eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, encoder->name, eptr);
+    pbuf = BRST_StrCopy(buf, "%%BeginResource: CMap (", eptr);
+    pbuf = BRST_StrCopy(pbuf, encoder->name, eptr);
     BRST_StrCopy(pbuf, ")\r\n", eptr);
     ret += BRST_Stream_WriteStr(cmap->stream, buf);
 
-    pbuf    = (char*)BRST_StrCopy(buf, "%%Title: (", eptr);
-    pbuf    = (char*)BRST_StrCopy(pbuf, encoder->name, eptr);
+    pbuf    = BRST_StrCopy(buf, "%%Title: (", eptr);
+    pbuf    = BRST_StrCopy(pbuf, encoder->name, eptr);
     *pbuf++ = ' ';
-    pbuf    = (char*)BRST_StrCopy(pbuf, attr->registry, eptr);
+    pbuf    = BRST_StrCopy(pbuf, attr->registry, eptr);
     *pbuf++ = ' ';
-    pbuf    = (char*)BRST_StrCopy(pbuf, attr->ordering, eptr);
+    pbuf    = BRST_StrCopy(pbuf, attr->ordering, eptr);
     *pbuf++ = ' ';
     pbuf    = BRST_IToA(pbuf, attr->supplement, eptr);
     BRST_StrCopy(pbuf, ")\r\n", eptr);
@@ -926,24 +926,24 @@ CreateCMap(BRST_Encoder encoder,
     ret += BRST_Stream_WriteStr(cmap->stream,
         "/CIDSystemInfo 3 dict dup begin\r\n");
 
-    pbuf = (char*)BRST_StrCopy(buf, "  /Registry (", eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, attr->registry, eptr);
+    pbuf = BRST_StrCopy(buf, "  /Registry (", eptr);
+    pbuf = BRST_StrCopy(pbuf, attr->registry, eptr);
     BRST_StrCopy(pbuf, ") def\r\n", eptr);
     ret += BRST_Stream_WriteStr(cmap->stream, buf);
 
-    pbuf = (char*)BRST_StrCopy(buf, "  /Ordering (", eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, attr->ordering, eptr);
+    pbuf = BRST_StrCopy(buf, "  /Ordering (", eptr);
+    pbuf = BRST_StrCopy(pbuf, attr->ordering, eptr);
     BRST_StrCopy(pbuf, ") def\r\n", eptr);
     ret += BRST_Stream_WriteStr(cmap->stream, buf);
 
-    pbuf = (char*)BRST_StrCopy(buf, "  /Supplement ", eptr);
+    pbuf = BRST_StrCopy(buf, "  /Supplement ", eptr);
     pbuf = BRST_IToA(pbuf, attr->supplement, eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, " def\r\n", eptr);
+    pbuf = BRST_StrCopy(pbuf, " def\r\n", eptr);
     BRST_StrCopy(pbuf, "end def\r\n\r\n", eptr);
     ret += BRST_Stream_WriteStr(cmap->stream, buf);
 
-    pbuf = (char*)BRST_StrCopy(buf, "/CMapName /", eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, encoder->name, eptr);
+    pbuf = BRST_StrCopy(buf, "/CMapName /", eptr);
+    pbuf = BRST_StrCopy(pbuf, encoder->name, eptr);
     BRST_StrCopy(pbuf, " def\r\n", eptr);
     ret += BRST_Stream_WriteStr(cmap->stream, buf);
 
@@ -951,13 +951,13 @@ CreateCMap(BRST_Encoder encoder,
     ret += BRST_Stream_WriteStr(cmap->stream, "/CMapType 1 def\r\n\r\n");
 
     if (attr->uid_offset >= 0) {
-        pbuf = (char*)BRST_StrCopy(buf, "/UIDOffset ", eptr);
+        pbuf = BRST_StrCopy(buf, "/UIDOffset ", eptr);
         pbuf = BRST_IToA(pbuf, attr->uid_offset, eptr);
         BRST_StrCopy(pbuf, " def\r\n\r\n", eptr);
         ret += BRST_Stream_WriteStr(cmap->stream, buf);
     }
 
-    pbuf    = (char*)BRST_StrCopy(buf, "/XUID [", eptr);
+    pbuf    = BRST_StrCopy(buf, "/XUID [", eptr);
     pbuf    = BRST_IToA(pbuf, attr->xuid[0], eptr);
     *pbuf++ = ' ';
     pbuf    = BRST_IToA(pbuf, attr->xuid[1], eptr);
@@ -966,7 +966,7 @@ CreateCMap(BRST_Encoder encoder,
     BRST_StrCopy(pbuf, "] def\r\n\r\n", eptr);
     ret += BRST_Stream_WriteStr(cmap->stream, buf);
 
-    pbuf = (char*)BRST_StrCopy(buf, "/WMode ", eptr);
+    pbuf = BRST_StrCopy(buf, "/WMode ", eptr);
     pbuf = BRST_IToA(pbuf, (BRST_UINT32)attr->writing_mode, eptr);
     BRST_StrCopy(pbuf, " def\r\n\r\n", eptr);
     ret += BRST_Stream_WriteStr(cmap->stream, buf);
@@ -1041,7 +1041,7 @@ CreateCMap(BRST_Encoder encoder,
 
         if ((i + 1) % 100 == 0) {
             phase--;
-            pbuf = (char*)BRST_StrCopy(buf, "endcidrange\r\n\r\n", eptr);
+            pbuf = BRST_StrCopy(buf, "endcidrange\r\n\r\n", eptr);
 
             if (phase > 0)
                 pbuf = BRST_IToA(pbuf, 100, eptr);
@@ -1058,15 +1058,15 @@ CreateCMap(BRST_Encoder encoder,
     }
 
     if (odd > 0)
-        pbuf = (char*)BRST_StrCopy(buf, "endcidrange\r\n", eptr);
+        pbuf = BRST_StrCopy(buf, "endcidrange\r\n", eptr);
 
-    pbuf = (char*)BRST_StrCopy(pbuf, "endcmap\r\n", eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, "CMapName currentdict /CMap "
+    pbuf = BRST_StrCopy(pbuf, "endcmap\r\n", eptr);
+    pbuf = BRST_StrCopy(pbuf, "CMapName currentdict /CMap "
                                     "defineresource pop\r\n",
         eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, "end\r\n", eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, "end\r\n\r\n", eptr);
-    pbuf = (char*)BRST_StrCopy(pbuf, "%%EndResource\r\n", eptr);
+    pbuf = BRST_StrCopy(pbuf, "end\r\n", eptr);
+    pbuf = BRST_StrCopy(pbuf, "end\r\n\r\n", eptr);
+    pbuf = BRST_StrCopy(pbuf, "%%EndResource\r\n", eptr);
     BRST_StrCopy(pbuf, "%%EOF\r\n", eptr);
     ret += BRST_Stream_WriteStr(cmap->stream, buf);
 

--- a/src/private/brst_font_type1.c
+++ b/src/private/brst_font_type1.c
@@ -326,13 +326,13 @@ Type1Font_OnWrite(BRST_Dict obj,
     if (!fontdef_attr->is_base14font || encoder_attr->has_differences) {
         char* pbuf;
 
-        pbuf = (char*)BRST_StrCopy(buf, "/FirstChar ", eptr);
+        pbuf = BRST_StrCopy(buf, "/FirstChar ", eptr);
         pbuf = BRST_IToA(pbuf, encoder_attr->first_char, eptr);
         BRST_StrCopy(pbuf, "\012", eptr);
         if ((ret = BRST_Stream_WriteStr(stream, buf)) != BRST_OK)
             return ret;
 
-        pbuf = (char*)BRST_StrCopy(buf, "/LastChar ", eptr);
+        pbuf = BRST_StrCopy(buf, "/LastChar ", eptr);
         pbuf = BRST_IToA(pbuf, encoder_attr->last_char, eptr);
         BRST_StrCopy(pbuf, "\012", eptr);
         if ((ret = BRST_Stream_WriteStr(stream, buf)) != BRST_OK)

--- a/src/private/brst_page.c
+++ b/src/private/brst_page.c
@@ -371,7 +371,7 @@ BRST_Dict_ResourceLocalName(BRST_Dict dict,
         char* ptr;
         char* end_ptr = localName + BRST_LIMIT_MAX_NAME_LEN;
 
-        ptr = (char*)BRST_StrCopy(localName, prefix, end_ptr);
+        ptr = BRST_StrCopy(localName, prefix, end_ptr);
         BRST_IToA(ptr, BRST_List_Count(resourceDict->list) + 1, end_ptr);
 
         if (BRST_Dict_Add(resourceDict, localName, resource) != BRST_OK)
@@ -455,7 +455,7 @@ BRST_Page_ShadingName(BRST_Page page,
         char* ptr;
         char* end_ptr = shading_str + BRST_LIMIT_MAX_NAME_LEN;
 
-        ptr = (char*)BRST_StrCopy(shading_str, "Sh", end_ptr);
+        ptr = BRST_StrCopy(shading_str, "Sh", end_ptr);
         BRST_IToA(ptr, BRST_List_Count(attr->shadings->list), end_ptr);
 
         if (BRST_Dict_Add(attr->shadings, shading_str, shading) != BRST_OK)

--- a/src/private/brst_utils.c
+++ b/src/private/brst_utils.c
@@ -243,7 +243,7 @@ BRST_MemCopy(BRST_BYTE* out,
     return out;
 }
 
-BRST_BYTE*
+BRST_STR
 BRST_StrCopy(char* out,
     const char* in,
     char* eptr)
@@ -255,7 +255,7 @@ BRST_StrCopy(char* out,
 
     *out = 0;
 
-    return (BRST_BYTE*)out;
+    return out;
 }
 
 BRST_INT

--- a/src/private/brst_xref.c
+++ b/src/private/brst_xref.c
@@ -274,7 +274,7 @@ BRST_Xref_WriteToStream(BRST_Xref xref,
         tmp_xref->addr = stream->size;
 
         pbuf    = buf;
-        pbuf    = (char*)BRST_StrCopy(pbuf, "xref\012", eptr);
+        pbuf    = BRST_StrCopy(pbuf, "xref\012", eptr);
         pbuf    = BRST_IToA(pbuf, tmp_xref->start_offset, eptr);
         *pbuf++ = ' ';
         pbuf    = BRST_IToA(pbuf, BRST_List_Count(tmp_xref->entries), eptr);


### PR DESCRIPTION
There are many security issues found by CI check.
This is the first attempt to fix some obvious of them.

Function `strcpy` is removed from demos, changed to `BRST_StrCopy`.
