### PR TITLE
Fix Cyrillic keyword typo and stray closing paren in gen/data

### DIFF
--- a/gen/data/doc_font.lsp
+++ b/gen/data/doc_font.lsp
@@ -71,7 +71,7 @@
                          :en "Path of AFM file")
                         (:type "CSTR"
                          :name "data_filename"
-                         :ру "Путь к файлу PFA/PFB"
+                         :ru "Путь к файлу PFA/PFB"
                          :en "Path of PFA/PFB file"))
             :result (:type "CSTR"
                         :ru "Наименование (идентификатор) шрифта при успехе, в противном случае возвращается \\c NULL и вызывается обработчик ошибок."

--- a/gen/data/doc_security.lsp
+++ b/gen/data/doc_security.lsp
@@ -14,7 +14,7 @@
                          :en "Owner password of the document.")
                         (:type "CSTR"
                          :name "user_password"
-                         :ру "Пользовательский пароль"
+                         :ru "Пользовательский пароль"
                          :en "User password of the document."))
             :result (:type "STATUS"
                         :ru ":return_ok"

--- a/gen/data/doc_viewer.lsp
+++ b/gen/data/doc_viewer.lsp
@@ -11,7 +11,7 @@
                       :en ":param_pdf")
                      (:type "Destination"
                       :name "open_action"
-                      :ру "Действие открытия страницы"
+                      :ru "Действие открытия страницы"
                       :en "Set a valid destination object."))
          :result (:type "STATUS"
                      :ru ":return_ok"
@@ -39,7 +39,7 @@
                       :en ":param_pdf")
                      (:type "ViewerPreference"
                       :name "value"
-                      :ру "Значение параметра"
+                      :ru "Значение параметра"
                       :en "Viewer preference value"))
          :result (:type "STATUS"
                      :ru ":return_ok"

--- a/gen/data/doc_xobject.lsp
+++ b/gen/data/doc_xobject.lsp
@@ -19,7 +19,7 @@
                          :en "Source image")
 			(:type "BOOL"
                          :name "zoom"
-                         :ру "Флаг масштабирования"
+                         :ru "Флаг масштабирования"
                          :en "Zoom flag"))
             :result (:type "XObject"
                         :ru ":param_xobject"

--- a/gen/data/encrypt.lsp
+++ b/gen/data/encrypt.lsp
@@ -27,4 +27,4 @@
 		     :value "4"
 		     :en "The security handler defines the use of encryption and decryption in the document."
 		     :ru "Управление шифрованием документа определяется настройками безопасности в документе."
-		     :version "1.5"))))))
+		     :version "1.5")))))


### PR DESCRIPTION
## Fix Cyrillic keyword typo and stray closing paren in gen/data

While building Ruby FFI bindings from `gen/data/*.lsp`, I noticed two small issues:

### 1. Cyrillic `:ру` instead of Latin `:ru` (4 files, 5 occurrences)

The following files use `:ру` (Cyrillic `р` U+0440 + Cyrillic `у` U+0443) instead of `:ru` (Latin `r` + `u`) as the keyword for Russian documentation strings:

- `gen/data/doc_font.lsp` (line 74)
- `gen/data/doc_security.lsp` (line 17)
- `gen/data/doc_viewer.lsp` (lines 14, 42)
- `gen/data/doc_xobject.lsp` (line 22)

The ECL pipeline is lenient enough that this works, but non-Lisp parsers (including the JSON/YAML generator from #26) may not pick up these entries as Russian documentation.

### 2. Stray closing paren in `gen/data/encrypt.lsp`

The file has 11 opening and 12 closing parentheses — one extra `)` at the end. Again, ECL tolerates this, but strict S-expression parsers will reject it.

Both fixes are trivial one-character changes.