### PR TITLE
Add S-expression sanity check for gen/data/*.lsp

### DIFF
--- a/.github/workflows/lsp-check.yml
+++ b/.github/workflows/lsp-check.yml
@@ -1,0 +1,24 @@
+name: LSP Sanity Check
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lsp-check:
+    name: Check gen/data/*.lsp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install sexpdata
+        run: pip install sexpdata
+
+      - name: Run LSP sanity check
+        run: python gen/scripts/check_lsp.py

--- a/gen/scripts/check_lsp.py
+++ b/gen/scripts/check_lsp.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Sanity-check every gen/data/*.lsp file.
+
+Two checks per file:
+  1. S-expression structure parses cleanly via sexpdata.
+  2. All keyword symbols (tokens beginning with ':') are ASCII-only,
+     so Cyrillic lookalikes such as :ру in place of :ru are caught.
+
+Exits with code 1 on any failure, printing one error per offending file.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import sexpdata
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = REPO_ROOT / "gen" / "data"
+
+
+def collect_symbols(node, out):
+    if isinstance(node, sexpdata.Symbol):
+        out.append(node)
+    elif isinstance(node, list):
+        for child in node:
+            collect_symbols(child, out)
+
+
+def check_file(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        parsed = sexpdata.loads("(" + text + ")")
+    except Exception as exc:
+        return [f"{path.relative_to(REPO_ROOT)}: parse error: {exc}"]
+
+    symbols: list[sexpdata.Symbol] = []
+    collect_symbols(parsed, symbols)
+
+    bad = []
+    for sym in symbols:
+        name = sym.value()
+        if name.startswith(":") and not name.isascii():
+            bad.append(name)
+
+    if bad:
+        unique = sorted(set(bad))
+        return [
+            f"{path.relative_to(REPO_ROOT)}: non-ASCII keyword(s): "
+            + ", ".join(repr(k) for k in unique)
+        ]
+    return []
+
+
+def main() -> int:
+    files = sorted(DATA_DIR.glob("*.lsp"))
+    if not files:
+        print(f"No .lsp files found under {DATA_DIR}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    for path in files:
+        errors.extend(check_file(path))
+
+    if errors:
+        for line in errors:
+            print(line)
+        print(f"\n{len(errors)} error(s) across {len(files)} file(s).")
+        return 1
+
+    print(f"All {len(files)} files passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Add S-expression sanity check for gen/data/*.lsp

As discussed with @dmitrys99 in #19: adds a CI workflow that validates all generator data files on every push and pull request.

### What it checks

1. **S-expression structure** — parses every `gen/data/*.lsp` file using Python's [`sexpdata`](https://pypi.org/project/sexpdata/) library. Catches unbalanced parentheses, malformed strings, and other structural errors (e.g. the stray `)` in `encrypt.lsp` fixed in #47).

2. **ASCII-only keywords** — verifies that all keyword tokens (`:foo`) are ASCII-only. Catches Cyrillic lookalike typos like `:ру` instead of `:ru` (also fixed in #47).

### Implementation

- **Workflow**: `.github/workflows/lsp-check.yml` — runs on `ubuntu-latest`, Python 3.12, single `pip install sexpdata` dependency.
- **Script**: `gen/scripts/check_lsp.py` — 78 lines, exits 1 on any error with a clear per-file message.

Similar lightweight approach to the spell check workflow in #18.

### Related
- #19 — request for this check
- #47 — the two bug classes this check would have caught